### PR TITLE
Feature - Connector first in getting the request

### DIFF
--- a/src/NextGen.php
+++ b/src/NextGen.php
@@ -2,12 +2,15 @@
 
 namespace Clinect\NextGen;
 
+use Clinect\NextGen\Requests\RequestResources;
 use Saloon\Http\Request;
 use Saloon\Http\Connector;
 use Saloon\Http\Paginators\PagedPaginator;
 
 class NextGen extends Connector
 {
+    use RequestResources;
+
     public int $perPage = 20;
 
     public function __construct(

--- a/src/Requests/RequestResources.php
+++ b/src/Requests/RequestResources.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Clinect\NextGen\Requests;
+
+trait RequestResources
+{
+    public function appointments(int|string|null $id = null): AppointmentRequests
+    {
+        return new AppointmentRequests($id);
+    }
+
+    public function charts(int|string|null $id = null): ChartRequests
+    {
+        return new ChartRequests($id);
+    }
+
+    public function departments(int|string|null $id = null): DepartmentRequests
+    {
+        return new DepartmentRequests($id);
+    }
+
+    public function healthHistoryForms(int|string|null $id = null): HealthHistoryFormRequests
+    {
+        return new HealthHistoryFormRequests($id);
+    }
+
+    public function insurances(int|string|null $id = null): InsuranceRequests
+    {
+        return new InsuranceRequests($id);
+    }
+
+    public function master(int|string|null $id = null): MasterRequests
+    {
+        return new MasterRequests($id);
+    }
+
+    public function patients(int|string|null $id = null): PatientRequests
+    {
+        return new PatientRequests($id);
+    }
+
+    public function persons(int|string|null $id = null): PersonRequests
+    {
+        return new PersonRequests($id);
+    }
+}

--- a/tests/Feature/Resources/Requests/AppointmentTests.php
+++ b/tests/Feature/Resources/Requests/AppointmentTests.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Clinect\NextGen\Tests\Feature\Resources\Requests;
+
+use Clinect\NextGen\NextGen;
+use Orchestra\Testbench\TestCase;
+use Clinect\NextGen\Tests\Stubs\Appointment as AppointmentStub;
+
+class AppointmentTests extends TestCase
+{
+    use AppointmentStub;
+
+    public function testCanSeeAllAppointments()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->appointments()->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+
+        foreach ($response->json() as $key => $result) {
+            $this->assertSame($this->all()[$key]['name'], $result['name']);
+            $this->assertSame($this->all()[$key]['category'], $result['category']);
+        }
+    }
+
+    public function testCanSeeAppointment()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->appointments('id-3')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Appointment 3');
+        $this->assertSame($response->json('category'), 'appointment-3');
+    }
+
+    public function testAppointmentNotFound()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->appointments('id-4')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 404);
+        $this->assertSame($response->json('error'), 'No data available');
+    }
+}

--- a/tests/Feature/Resources/Requests/Appointments/HealthHistoryFormTests.php
+++ b/tests/Feature/Resources/Requests/Appointments/HealthHistoryFormTests.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Clinect\NextGen\Tests\Feature\Resources\Requests\Appointments;
+
+use Clinect\NextGen\NextGen;
+use Orchestra\Testbench\TestCase;
+use Clinect\NextGen\Tests\Stubs\Appointment as AppointmentStub;
+
+class HealthHistoryFormTests extends TestCase
+{
+    use AppointmentStub;
+
+    public function testCanSeeAllAppointmentHealthHistoryForms()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->appointments('appointment-id')->withPracticeId('practice-id')->healthHistoryForms()->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+
+        foreach ($response->json() as $key => $result) {
+            $this->assertSame($this->healthHistoryForms()[$key]['name'], $result['name']);
+            $this->assertSame($this->healthHistoryForms()[$key]['category'], $result['category']);
+        }
+    }
+
+    public function testCanSeeAppointmentHealthHistoryForm()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->appointments('appointment-id')->withPracticeId('practice-id')->healthHistoryForms('id-3')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Appointment health history 3');
+        $this->assertSame($response->json('category'), 'appointment-health-history-3');
+    }
+
+    public function testAppointmentHealthHistoryFormNotFound()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->appointments('appointment-id')->withPracticeId('practice-id')->healthHistoryForms('id-4')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 404);
+        $this->assertSame($response->json('error'), 'No data available');
+    }
+}

--- a/tests/Feature/Resources/Requests/ChartTests.php
+++ b/tests/Feature/Resources/Requests/ChartTests.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Clinect\NextGen\Tests\Feature\Resources\Requests;
+
+use Clinect\NextGen\NextGen;
+use Orchestra\Testbench\TestCase;
+use Clinect\NextGen\Tests\Stubs\Chart as ChartStub;
+
+class ChartTests extends TestCase
+{
+    use ChartStub;
+
+    public function testCanSeeAllCharts()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->charts()->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+
+        foreach ($response->json() as $key => $result) {
+            $this->assertSame($this->all()[$key]['name'], $result['name']);
+            $this->assertSame($this->all()[$key]['category'], $result['category']);
+        }
+    }
+
+    public function testCanSeeChart()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->charts('id-3')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Chart 3');
+        $this->assertSame($response->json('category'), 'chart-3');
+    }
+
+    public function testAppointmentNotFound()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->charts('id-4')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 404);
+        $this->assertSame($response->json('error'), 'No data available');
+    }
+}

--- a/tests/Feature/Resources/Requests/DepartmentTests.php
+++ b/tests/Feature/Resources/Requests/DepartmentTests.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Clinect\NextGen\Tests\Feature\Resources\Requests\Persons;
+
+use Clinect\NextGen\NextGen;
+use Orchestra\Testbench\TestCase;
+use Clinect\NextGen\Tests\Stubs\Department as DepartmentStub;
+
+class DepartmentTests extends TestCase
+{
+    use DepartmentStub;
+
+    public function testCanSeeAllCharges()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->departments()->withPracticeId('practice-id')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+
+        foreach ($response->json() as $key => $result) {
+            $this->assertSame($this->all()[$key]['name'], $result['name']);
+            $this->assertSame($this->all()[$key]['category'], $result['category']);
+        }
+    }
+
+    public function testCanSeeCharge()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->departments('id-3')->withPracticeId('practice-id')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Department 3');
+        $this->assertSame($response->json('category'), 'department-3');
+    }
+
+    public function testChargeNotFound()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->departments('department-id')->withPracticeId('practice-id')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 404);
+        $this->assertSame($response->json('error'), 'No data available');
+    }
+}

--- a/tests/Feature/Resources/Requests/HealthHistoryFormTests.php
+++ b/tests/Feature/Resources/Requests/HealthHistoryFormTests.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Clinect\NextGen\Tests\Feature\Resources\Requests;
+
+use Clinect\NextGen\NextGen;
+use Orchestra\Testbench\TestCase;
+use Clinect\NextGen\Tests\Stubs\HealthHistoryForm as HealthHistoryFormStub;
+
+class HealthHistoryFormTests extends TestCase
+{
+    use HealthHistoryFormStub;
+
+    public function testCanSeeAllAppointments()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->healthHistoryForms()->withPracticeId('practice-id')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+
+        foreach ($response->json() as $key => $result) {
+            $this->assertSame($this->all()[$key]['name'], $result['name']);
+            $this->assertSame($this->all()[$key]['category'], $result['category']);
+        }
+    }
+
+    public function testCanSeeAppointment()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->healthHistoryForms('id-3')->withPracticeId('practice-id')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Health history 3');
+        $this->assertSame($response->json('category'), 'health-history-3');
+    }
+
+    public function testAppointmentNotFound()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->healthHistoryForms('id-4')->withPracticeId('practice-id')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 404);
+        $this->assertSame($response->json('error'), 'No data available');
+    }
+}

--- a/tests/Feature/Resources/Requests/PatientTests.php
+++ b/tests/Feature/Resources/Requests/PatientTests.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Clinect\NextGen\Tests\Feature\Resources\Requests;
+
+use Clinect\NextGen\NextGen;
+use Orchestra\Testbench\TestCase;
+use Clinect\NextGen\Tests\Stubs\Patient as PatientStub;
+
+class PatientTests extends TestCase
+{
+    use PatientStub;
+
+    public function testCanSeePerson()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->patients('id-3')->withPracticeId('practice-id')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Patient 3');
+        $this->assertSame($response->json('category'), 'patient-3');
+    }
+
+    public function testPersonNotFound()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->patients('id-4')->withPracticeId('practice-id')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 404);
+        $this->assertSame($response->json('error'), 'No data available');
+    }
+}

--- a/tests/Feature/Resources/Requests/PersonTests.php
+++ b/tests/Feature/Resources/Requests/PersonTests.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Clinect\NextGen\Tests\Feature\Resources\Requests;
+
+use Clinect\NextGen\NextGen;
+use Orchestra\Testbench\TestCase;
+use Clinect\NextGen\Tests\Stubs\Person as PersonStub;
+
+class PersonTests extends TestCase
+{
+    use PersonStub;
+
+    public function testCanSeeAllPersons()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons()->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+
+        foreach ($response->json() as $key => $result) {
+            $this->assertSame($this->persons()[$key]['name'], $result['name']);
+            $this->assertSame($this->persons()[$key]['category'], $result['category']);
+        }
+    }
+
+    public function testCanSeePerson()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('id-3')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Person 3');
+        $this->assertSame($response->json('category'), 'person-3');
+    }
+
+    public function testPersonNotFound()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('id-4')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 404);
+        $this->assertSame($response->json('error'), 'No data available');
+    }
+}

--- a/tests/Feature/Resources/Requests/Persons/BalanceTests.php
+++ b/tests/Feature/Resources/Requests/Persons/BalanceTests.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Clinect\NextGen\Tests\Feature\Resources\Requests\Persons;
+
+use Clinect\NextGen\NextGen;
+use Orchestra\Testbench\TestCase;
+use Clinect\NextGen\Tests\Stubs\Person as PersonStub;
+
+class BalanceTests extends TestCase
+{
+    use PersonStub;
+
+    public function testCanSeeAllBalances()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')->balances()->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+
+        foreach ($response->json() as $key => $result) {
+            $this->assertSame($this->balances()[$key]['name'], $result['name']);
+            $this->assertSame($this->balances()[$key]['category'], $result['category']);
+        }
+    }
+
+    public function testCanSeeBalance()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')->balances('id-3')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Person balance 3');
+        $this->assertSame($response->json('category'), 'person-balance-3');
+    }
+
+    public function testBalanceNotFound()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')->balances('id-4')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 404);
+        $this->assertSame($response->json('error'), 'No data available');
+    }
+}

--- a/tests/Feature/Resources/Requests/Persons/ChargeTests.php
+++ b/tests/Feature/Resources/Requests/Persons/ChargeTests.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Clinect\NextGen\Tests\Feature\Resources\Requests\Persons;
+
+use Clinect\NextGen\NextGen;
+use Orchestra\Testbench\TestCase;
+use Clinect\NextGen\Tests\Stubs\Person as PersonStub;
+
+class ChargeTests extends TestCase
+{
+    use PersonStub;
+
+    public function testCanSeeAllCharges()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')->charges()->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+
+        foreach ($response->json() as $key => $result) {
+            $this->assertSame($this->charges()[$key]['name'], $result['name']);
+            $this->assertSame($this->charges()[$key]['category'], $result['category']);
+        }
+    }
+
+    public function testCanSeeCharge()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')->charges('id-3')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Person charge 3');
+        $this->assertSame($response->json('category'), 'person-charge-3');
+    }
+
+    public function testChargeNotFound()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')->charges('id-4')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 404);
+        $this->assertSame($response->json('error'), 'No data available');
+    }
+}

--- a/tests/Feature/Resources/Requests/Persons/ChartTests.php
+++ b/tests/Feature/Resources/Requests/Persons/ChartTests.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Clinect\NextGen\Tests\Feature\Resources\Requests\Persons;
+
+use Clinect\NextGen\NextGen;
+use Orchestra\Testbench\TestCase;
+use Clinect\NextGen\Tests\Stubs\Person as PersonStub;
+
+class ChartTests extends TestCase
+{
+    use PersonStub;
+
+    public function testCanSeeAllCharges()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')->charts()->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+
+        foreach ($response->json() as $key => $result) {
+            $this->assertSame($this->charts()[$key]['name'], $result['name']);
+            $this->assertSame($this->charts()[$key]['category'], $result['category']);
+        }
+    }
+
+    public function testCanSeeCharge()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')->charts('id-3')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Person chart 3');
+        $this->assertSame($response->json('category'), 'person-chart-3');
+    }
+
+    public function testChargeNotFound()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')->charts('id-4')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 404);
+        $this->assertSame($response->json('error'), 'No data available');
+    }
+}

--- a/tests/Feature/Resources/Requests/Persons/EncounterTests.php
+++ b/tests/Feature/Resources/Requests/Persons/EncounterTests.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Clinect\NextGen\Tests\Feature\Resources\Requests\Persons;
+
+use Clinect\NextGen\NextGen;
+use Orchestra\Testbench\TestCase;
+use Clinect\NextGen\Tests\Stubs\Person as PersonStub;
+
+class EncounterTests extends TestCase
+{
+    use PersonStub;
+
+    public function testCanSeeAllCharges()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')->encounters()->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+
+        foreach ($response->json() as $key => $result) {
+            $this->assertSame($this->encounters()[$key]['name'], $result['name']);
+            $this->assertSame($this->encounters()[$key]['category'], $result['category']);
+        }
+    }
+
+    public function testCanSeeCharge()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')->encounters('id-3')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Person encounter 3');
+        $this->assertSame($response->json('category'), 'person-encounter-3');
+    }
+
+    public function testChargeNotFound()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')->encounters('id-4')->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 404);
+        $this->assertSame($response->json('error'), 'No data available');
+    }
+}

--- a/tests/Feature/Resources/Requests/Persons/InsuranceCardTests.php
+++ b/tests/Feature/Resources/Requests/Persons/InsuranceCardTests.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Clinect\NextGen\Tests\Feature\Resources\Requests\Persons;
+
+use Clinect\NextGen\NextGen;
+use Orchestra\Testbench\TestCase;
+use Clinect\NextGen\Tests\Stubs\Person as PersonStub;
+
+class InsuranceCardTests extends TestCase
+{
+    use PersonStub;
+
+    public function testCanSeeAllInsuranceCards()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')
+            ->insurances('insurance-id')
+            ->cards()
+            ->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+
+        foreach ($response->json() as $key => $result) {
+            $this->assertSame($this->insuranceCards()[$key]['name'], $result['name']);
+            $this->assertSame($this->insuranceCards()[$key]['category'], $result['category']);
+        }
+    }
+
+    public function testCanSeeInsuranceCard()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')
+            ->insurances('insurance-id')
+            ->cards('id-3')
+            ->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Person insurance card 3');
+        $this->assertSame($response->json('category'), 'person-insurance-card-3');
+    }
+
+    public function testCanSeeInsuranceCardBack()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')
+            ->insurances('insurance-id')
+            ->cards('card-id')
+            ->back()
+            ->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Person insurance card back 3');
+        $this->assertSame($response->json('category'), 'person-insurance-card-back-3');
+    }
+
+    public function testCanSeeInsuranceCardFront()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')
+            ->insurances('insurance-id')
+            ->cards('card-id')
+            ->front()
+            ->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Person insurance card front 3');
+        $this->assertSame($response->json('category'), 'person-insurance-card-front-3');
+    }
+
+    public function testInsuranceCardNotFound()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')
+            ->insurances('insurance-id')
+            ->cards('id-4')
+            ->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 404);
+        $this->assertSame($response->json('error'), 'No data available');
+    }
+}

--- a/tests/Feature/Resources/Requests/Persons/InsuranceTests.php
+++ b/tests/Feature/Resources/Requests/Persons/InsuranceTests.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Clinect\NextGen\Tests\Feature\Resources\Requests\Persons;
+
+use Clinect\NextGen\NextGen;
+use Orchestra\Testbench\TestCase;
+use Clinect\NextGen\Tests\Stubs\Person as PersonStub;
+
+class InsuranceTests extends TestCase
+{
+    use PersonStub;
+
+    public function testCanSeeAllInsurances()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')
+            ->insurances()
+            ->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+
+        foreach ($response->json() as $key => $result) {
+            $this->assertSame($this->insurances()[$key]['name'], $result['name']);
+            $this->assertSame($this->insurances()[$key]['category'], $result['category']);
+        }
+    }
+
+    public function testCanSeeInsurance()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')
+            ->insurances('id-3')
+            ->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 200);
+        $this->assertSame($response->json('name'), 'Person insurance 3');
+        $this->assertSame($response->json('category'), 'person-insurance-3');
+    }
+
+    public function testInsuranceNotFound()
+    {
+        $baseUrl = 'test.clinect.com';
+
+        $connector = new NextGen(baseUrl: $baseUrl);
+
+        $connector->withMockClient($this->client($baseUrl));
+
+        $request = $connector->persons('person-id')
+            ->insurances('id-4')
+            ->get();
+
+        $response = $connector->send($request);
+
+        $this->assertSame($response->status(), 404);
+        $this->assertSame($response->json('error'), 'No data available');
+    }
+}


### PR DESCRIPTION
This is just a nice to have, it does not affect what we currently have in the `master` branch, it gives the dev/user the option to use the **connector first method** in getting the request.

This also makes all the transactions related to NextGen to go through the NextGen Connector. 
Importing of the request will also be done in the sdk instead of the app using the sdk.

**Usage: Get All Appointment**
_**Request Level:**_ 
```
$request = (new AppointmentRequests)->get();
$request = (new AppointmentRequests($appointmentId))->get();
```
_**Connector First:**_ 
```
$request = $connector->appointments()->get();
$request = $connector->appointments($appointmentId)->get();
```


**Usage: Person Insurance Card**
_**Request Level:**_ 
```
$request = new PersonRequests($personId))
            ->insurances($insuranceId)
            ->cards($cardId)
            ->back()
            ->get();
```
_**Connector First:**_ 
```
$request = $connector->persons($personId)
            ->insurances($insuranceId)
            ->cards($cardId)
            ->back()
            ->get();
```